### PR TITLE
Added ability to space out section syntax

### DIFF
--- a/mustache/Mustache.cfc
+++ b/mustache/Mustache.cfc
@@ -22,13 +22,13 @@
 	<!--- namespace for Mustache private variables (to avoid name collisions when extending Mustache.cfc) --->
 	<cfset variables.Mustache = structNew() />
 	<cfset variables.Mustache.Pattern=createObject("java","java.util.regex.Pattern") />
-	
+
 	<!--- captures the ".*" match for looking for formatters (see #2) and also allows nested structure references (see #3), removes looking for comments --->
 	<cfset variables.Mustache.TagRegEx = variables.Mustache.Pattern.compile("\{\{(\{|&|\>)?\s*((?:\w+(?:(?:\.\w+){1,})?)|\.)(.*?)\}?\}\}", 32)/>
 	<!--- Partial regex --->
 	<cfset variables.Mustache.PartialRegEx = variables.Mustache.Pattern.compile("\{\{\>\s*((?:\w+(?:(?:\.\w+){1,})?)|\.)(.*?)\}?\}\}", 32)/>
 	<!--- captures nested structure references --->
-	<cfset variables.Mustache.SectionRegEx = variables.Mustache.Pattern.compile("\{\{(##|\^)\s*(\w+(?:(?:\.\w+){1,})?)\s*}}(.*?)\{\{/\s*\2\s*\}\}", 32)/>
+	<cfset variables.Mustache.SectionRegEx = variables.Mustache.Pattern.compile("\{\{\s*(##|\^)\s*(\w+(?:(?:\.\w+){1,})?)\s*}}(.*?)\{\{\s*/\s*\2\s*\}\}", 32)/>
 	<!--- captures nested structure references --->
 	<cfset variables.Mustache.CommentRegEx = variables.Mustache.Pattern.compile("((^\r?\n?)|\s+)?\{\{!.*?\}\}(\r?\n?(\r?\n?)?)?", 40)/>
 	<!--- captures nested structure references --->
@@ -51,10 +51,10 @@
 		<cfargument name="context" default="#this#"/>
 		<cfargument name="partials" hint="the partial objects" required="true" default="#structNew()#"/>
 		<cfargument name="options" hint="options object (can be used in overridden functions to pass additional instructions)" required="false" default="#structNew()#"/>
-		
+
 		<!--- Replace partials in template --->
 		<cfset arguments.template=replacePartialsInTemplate(arguments.template,arguments.partials) />
-		
+
 		<cfset var results = renderFragment(argumentCollection=arguments)/>
 
 		<!--- remove single blank lines at the head/tail of the stream --->
@@ -66,18 +66,18 @@
 	<cffunction name="replacePartialsInTemplate" access="private" output="false">
 		<cfargument name="template" />
 		<cfargument name="partials"/>
-		
+
 		<cfset local.matches = ReFindNoCaseValues(arguments.template, variables.Mustache.PartialRegEx)/>
-		
+
 		<cfif arrayLen(local.matches)>
 			<cfset local.partial = getPartial(trim(local.matches[2]),arguments.partials) />
 			<cfset local.result= ReplaceNoCase(arguments.template,local.matches[1],local.partial) />
 		<cfelse>
 			<cfset local.result=arguments.template />
-		</cfif>		
-		
+		</cfif>
+
 		<cfreturn local.result />
-		
+
 	</cffunction>
 
 	<cffunction name="renderFragment" access="private" output="false"
@@ -256,7 +256,7 @@
 		<cfset arguments.template = rtrim(arguments.template)/>
 
 		<cfsavecontent variable="local.results"><cfloop array="#arguments.context#" index="local.item"><cfoutput>#renderFragment(arguments.template, local.item, arguments.partials, arguments.options)#</cfoutput></cfloop></cfsavecontent>
-		
+
 		<cfreturn local.results />
 	</cffunction>
 
@@ -431,16 +431,16 @@
 
 		<cfreturn local.results/>
 	</cffunction>
-	
+
 	<cffunction name="getPartial" access="private" output="false">
 		<cfargument name="name" hint="the name of the partial" required="true">
 		<cfargument name="partials" hint="the partials object" required="false">
-		
+
 		<cfif structKeyExists(variables.Mustache.partials,arguments.name)>
 			<cfreturn variables.Mustache.partials[arguments.name] />
-		<cfelseif structKeyExists(arguments,"partials") and structKeyExists(arguments.partials, arguments.name)>	
+		<cfelseif structKeyExists(arguments,"partials") and structKeyExists(arguments.partials, arguments.name)>
 			<cfreturn arguments.partials[arguments.name] />
-		<cfelse>	
+		<cfelse>
 			<!--- Fetch from file as last resort --->
 			<cfreturn readMustacheFile(arguments.name) />
 		</cfif>

--- a/tests/RenderTest.cfc
+++ b/tests/RenderTest.cfc
@@ -21,6 +21,18 @@
     <cfset expected = "Hello, World!" />
   </cffunction>
 
+  <cffunction name="basicWithSpace">
+    <cfset context = { thing = 'world'} />
+    <cfset template = "Hello, {{ thing }}!" />
+    <cfset expected = "Hello, World!" />
+  </cffunction>
+
+  <cffunction name="basicWithMuchSpace">
+    <cfset context = { thing = 'world'} />
+    <cfset template = "Hello, {{             thing    }}!" />
+    <cfset expected = "Hello, World!" />
+  </cffunction>
+
   <cffunction name="lessBasic">
     <cfset context = { beverage = 'soda', person = 'Bob' } />
     <cfset template = "It's a nice day for {{beverage}}, right {{person}}?" />
@@ -62,6 +74,18 @@
    <cffunction name="trueSectionsAreShown">
     <cfset context =  { set = true }  />
     <cfset template = "Ready {{##set}}set {{/set}}go!" />
+    <cfset expected = "Ready set go!" />
+  </cffunction>
+
+  <cffunction name="falseSectionsWithSpaceAreHidden">
+    <cfset context =  { set = false } />
+    <cfset template = "Ready {{ ##set }}set {{ /set }}go!" />
+    <cfset expected = "Ready go!" />
+  </cffunction>
+
+   <cffunction name="trueSectionsWithSpaceAreShown">
+    <cfset context =  { set = true }  />
+    <cfset template = "Ready {{ ##set }}set {{ /set }}go!" />
     <cfset expected = "Ready set go!" />
   </cffunction>
 


### PR DESCRIPTION
Tweaked the SectionRegEx to allow some arbitrary whitespace after the {{
but before the # or / and then before the }}. Instead of requiring you
to write: {{#is_old}} you can write {{ #is_old }}.

Added tests for this new flexibility and to verify that this same space
leniency already existed for tags.